### PR TITLE
Removes sequence search as an option for traditional search results

### DIFF
--- a/CAP/root/templates/Default/Common/partial/page_viewer.tt
+++ b/CAP/root/templates/Default/Common/partial/page_viewer.tt
@@ -5,7 +5,7 @@
     <div id="pvImageInner">
       <noscript><img id="pvImg" src="[% first_uri %]" alt="[% first_label %]"></noscript>
     </div>
-    <aside id="pvSearch" class="pv-overlay px-3 pt-3[% UNLESS item.record.component_count_fulltext %] hidden[% END %]">
+    <aside id="pvSearch" class="pv-overlay px-3 pt-3 hidden">
       [% INCLUDE partial/item_keyword_search.tt label=item.canonical_label key=record.key %]
     </aside>
     <aside id="pvComponent" class="pv-overlay p-3[% UNLESS item.component(seq).hasTags %] hidden[% END %]">

--- a/CAP/root/templates/Default/Common/partial/page_viewer/toolbar_bottom.tt
+++ b/CAP/root/templates/Default/Common/partial/page_viewer/toolbar_bottom.tt
@@ -1,6 +1,6 @@
 [% first_child = item.component(seq) -%]
 <nav id="pvToolbarBottom" aria-label="[% c.loc("L_VIEWER_LABEL") %]" class="btn-toolbar form-inline px-1">
-  [% IF item.record.component_count_fulltext; WRAPPER button_svg tag="button" label=c.loc("L_VIEWER_TOGGLE_SEARCH") id="pvSearchToggle" active=1 %]
+  [% IF item.record.component_count_fulltext; WRAPPER button_svg tag="button" label=c.loc("L_VIEWER_TOGGLE_SEARCH") id="pvSearchToggle" active=0 %]
     <svg xmlns="http://www.w3.org/2000/svg" focusable="false" width="22" height="22" fill="currentColor" class="bi bi-search" viewBox="0 0 16 16">
       <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
     </svg>

--- a/CAP/root/templates/Default/Common/partial/search_controls/basic.tt
+++ b/CAP/root/templates/Default/Common/partial/search_controls/basic.tt
@@ -4,7 +4,7 @@
 <input type="hidden" name="pkey" value="[% search_params.pkey %]" />
 <p class="mt-3">
   <a href="[% c.uri_for_action("/search/index", c.req.mangle_params({ pkey => "" })) %]">[&times;]</a>
-  [% c.loc("L_SEARCH_WITHIN") %] <a href="[% c.uri_for_action("view/index", search_params.pkey) %]"><i>[% resultset.documents.0.plabel %]</i></a>.
+  [% c.loc("L_SEARCH_WITHIN") %] <a href="[% c.uri_for_action("view/index", search_params.pkey) %]"><i>[% resultset.documents.0.plabel || search_params.pkey %]</i></a>.
 </p>
 [% END -%]
 [% IF portal.has_subcollections && search_handler != "page" -%]

--- a/CAP/root/templates/Default/Common/partial/search_controls/sort_order.tt
+++ b/CAP/root/templates/Default/Common/partial/search_controls/sort_order.tt
@@ -11,7 +11,6 @@
       [% WRAPPER refine_link field="so" value="score" active=search_params.sort %][% c.loc("L_SEARCH_SORT_SCORE") %][% END %]
       [% WRAPPER refine_link field="so" value="newest" active=search_params.sort %][% c.loc("L_SEARCH_SORT_NEWEST") %][% END %]
       [% WRAPPER refine_link field="so" value="oldest" active=search_params.sort %][% c.loc("L_SEARCH_SORT_OLDEST") %][% END %]
-      [% IF search_params.pkey; WRAPPER refine_link field="so" value="seq" active=search_params.sort %][% c.loc("L_SEARCH_SORT_SEQUENCE") %][% END; END %]
     </div>
   [% END %]
 [% END %]

--- a/CAP/root/templates/Default/Common/partial/series_keyword_search.tt
+++ b/CAP/root/templates/Default/Common/partial/series_keyword_search.tt
@@ -8,7 +8,6 @@
 <form class="form-inline" id="keywordSearch" method="POST" action="[% c.uri_for_action("/search/post") %]">
   <input type="hidden" name="handler" value="general" />
   <input type="hidden" name="pkey" value="[% key %]" />
-  <input type="hidden" name="so" value="seq" />
   <label for="query" class="mr-1">[% search_label %]</label>
   <input type="text" id="query" class="form-control mr-2" name="q" />
   <button type="submit" class="btn btn-primary" value="keyword_search">[% c.loc("L_SEARCH_IMPERATIVE") %]</button>


### PR DESCRIPTION
This will allow us to avoid providing `seq` in our manifest records, which will save a load of processing time.

Refinements in date ordering that are coming sooner rather than later will replace the functionality.

`seq` search is still used in matching page searches.

This PR also makes the search pane hidden by default in the page viewer. It was visible by default, partially because a not-very-well-maintained non-JavaScript matching page search was possible until this change.

Closes #65.